### PR TITLE
Fix facilitator mode bugs, thread safety, and OLED display quality

### DIFF
--- a/feedback_hardware.py
+++ b/feedback_hardware.py
@@ -35,6 +35,7 @@ _draw: Optional[Any] = None
 _font: Optional[Any] = None
 _image: Optional[Any] = None
 _facilitator_button_callback: Optional[Any] = None
+_on_idle_callback: Optional[Any] = None
 
 # Try to import GPIO libraries (gpiozero for RGB LED and piezo)
 try:
@@ -86,7 +87,7 @@ OLED_HEIGHT = 128
 
 def _initialize_hardware() -> None:
     """Initialize hardware components if available (only runs once)."""
-    global _rgb_led, _piezo, _facilitator_button, _oled, _draw, _font, _image, _hardware_initialized
+    global _rgb_led, _piezo, _oled, _draw, _font, _image, _hardware_initialized
 
     # Skip if already initialized
     if _hardware_initialized:
@@ -119,21 +120,6 @@ def _initialize_hardware() -> None:
             LOG.warning("Failed to initialize piezo buzzer: %s", exc)
             _piezo = None
 
-    if (
-        _HAS_GPIO
-        and _facilitator_button is None
-        and _facilitator_button_callback is not None
-    ):
-        try:
-            _facilitator_button = Button(
-                FACILITATOR_BUTTON_PIN, pull_up=True, bounce_time=0.2
-            )
-            _facilitator_button.when_pressed = _handle_facilitator_button_pressed
-            LOG.info("Facilitator button initialized on pin %d", FACILITATOR_BUTTON_PIN)
-        except Exception as exc:
-            LOG.warning("Failed to initialize facilitator button: %s", exc)
-            _facilitator_button = None
-
     # Initialize OLED display
     if _HAS_OLED and _oled is None:
         try:
@@ -142,8 +128,9 @@ def _initialize_hardware() -> None:
             _oled.fill(0)
             _oled.show()
 
-            # Create blank image for drawing
-            _image = Image.new("1", (_oled.width, _oled.height))
+            # Use 8-bit greyscale so Pillow can anti-alias TrueType glyphs.
+            # The image is thresholded to 1-bit just before sending to the display.
+            _image = Image.new("L", (_oled.width, _oled.height))
             _draw = ImageDraw.Draw(_image)
 
             # Try to load a TrueType font from common locations
@@ -155,7 +142,7 @@ def _initialize_hardware() -> None:
             ]
             for font_path in font_paths:
                 try:
-                    _font = ImageFont.truetype(font_path, 12)
+                    _font = ImageFont.truetype(font_path, 14)
                     break
                 except Exception:
                     continue
@@ -219,8 +206,67 @@ def _handle_facilitator_button_pressed() -> None:
             LOG.exception("Facilitator button callback failed: %s", exc)
 
 
+def _measure_text(text: str) -> int:
+    """Return the pixel width of text rendered in the current font."""
+    if _draw is None:
+        return len(text) * 8
+    try:
+        return int(_draw.textbbox((0, 0), text, font=_font)[2])
+    except Exception:
+        try:
+            w, _ = _draw.textsize(text, font=_font)  # type: ignore[attr-defined]
+            return w
+        except Exception:
+            return len(text) * 8
+
+
+def _wrap_and_clip(lines: List[str], max_width: int, max_lines: int) -> List[str]:
+    """Word-wrap lines to fit max_width pixels, then cap at max_lines.
+
+    Lines that cannot be word-wrapped (e.g. a single long word) are truncated
+    with an ellipsis.
+    """
+    result: List[str] = []
+    for raw in lines:
+        if len(result) >= max_lines:
+            break
+        if _measure_text(raw) <= max_width:
+            result.append(raw)
+            continue
+        # Word-wrap
+        words = raw.split()
+        current = ""
+        for word in words:
+            if len(result) >= max_lines:
+                break
+            candidate = (current + " " + word).strip() if current else word
+            if _measure_text(candidate) <= max_width:
+                current = candidate
+            else:
+                if current:
+                    result.append(current)
+                current = word
+        if current and len(result) < max_lines:
+            result.append(current)
+
+    # Truncate any line that still overflows (e.g. a single word wider than the display)
+    clipped: List[str] = []
+    for line in result:
+        if _measure_text(line) <= max_width:
+            clipped.append(line)
+        else:
+            while line and _measure_text(line + "…") > max_width:
+                line = line[:-1]
+            clipped.append(line + "…")
+    return clipped
+
+
 def _display_text(lines: List[str], clear: bool = True) -> None:
-    """Display text on OLED screen."""
+    """Display text on OLED screen.
+
+    Lines are word-wrapped to fit within the horizontal margins and clipped
+    to the number of lines that fit vertically below y_offset.
+    """
     if _oled is None or _draw is None or _image is None:
         return
 
@@ -228,15 +274,17 @@ def _display_text(lines: List[str], clear: bool = True) -> None:
         if clear:
             _draw.rectangle((0, 0, _oled.width, _oled.height), outline=0, fill=0)
 
-        line_height = 18
-        y_offset = 74  # Start further down from the top (moved down by 2 lines)
         x_margin = 10
+        y_offset = 74
+        line_height = 18
+        max_width = _oled.width - 2 * x_margin
+        max_lines = max(1, (_oled.height - y_offset) // line_height)
 
-        for line in lines:
+        for line in _wrap_and_clip(lines, max_width, max_lines):
             _draw.text((x_margin, y_offset), line, font=_font, fill=255)
             y_offset += line_height
 
-        _oled.image(_image)
+        _oled.image(_image.convert("1"))
         _oled.show()
     except Exception as exc:
         LOG.warning("Failed to display text on OLED: %s", exc)
@@ -283,10 +331,15 @@ def _schedule_led_and_oled_clear(delay_seconds: float = 3.0) -> None:
     if _led_clear_timer is not None:
         _led_clear_timer.cancel()
 
-    # Define the clear function - returns to ready state
+    # Define the clear function - returns to idle state via registered callback
     def _clear_and_ready():
-        # Return to ready state
-        provide_feedback(FeedbackState.READY_TO_SCAN)
+        if _on_idle_callback is not None:
+            try:
+                _on_idle_callback()
+            except Exception as exc:
+                LOG.exception("Idle callback failed: %s", exc)
+        else:
+            provide_feedback(FeedbackState.READY_TO_SCAN)
 
     # Schedule new timer
     _led_clear_timer = threading.Timer(delay_seconds, _clear_and_ready)
@@ -298,7 +351,6 @@ def provide_feedback(
     state: FeedbackState,
     message: str = "",
     workshop: str = "",
-    workshop_callback: Optional[Any] = None,
 ) -> None:
     """Provide hardware feedback for a given state.
 
@@ -455,7 +507,7 @@ def register_facilitator_button(callback: Any) -> bool:
     if _facilitator_button is None:
         try:
             _facilitator_button = Button(
-                FACILITATOR_BUTTON_PIN, pull_up=True, bounce_time=0.2
+                FACILITATOR_BUTTON_PIN, pull_up=False, bounce_time=0.2
             )
             LOG.info("Facilitator button initialized on pin %d", FACILITATOR_BUTTON_PIN)
         except Exception as exc:
@@ -465,6 +517,18 @@ def register_facilitator_button(callback: Any) -> bool:
 
     _facilitator_button.when_pressed = _handle_facilitator_button_pressed
     return True
+
+
+def register_idle_callback(callback: Any) -> None:
+    """Register a callback invoked whenever the display returns to the idle/ready state.
+
+    The callback is called by the auto-clear timer after error states (CARD_NOT_EXIST,
+    SCAN_ERROR, SYSTEM_UNAVAILABLE) expire.  Registering from signin.py lets the timer
+    show the correct idle screen (normal or facilitator) without feedback_hardware.py
+    needing to know about signin state.
+    """
+    global _on_idle_callback
+    _on_idle_callback = callback
 
 
 def shutdown_hardware() -> None:

--- a/signin.py
+++ b/signin.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import datetime
 import logging
 import os
+import threading
 import time
 from typing import Any, Dict, List, Optional, Tuple, Union
 
@@ -33,6 +34,7 @@ try:
         FeedbackState,
         provide_feedback,
         register_facilitator_button,
+        register_idle_callback,
         shutdown_hardware,
     )
 
@@ -102,8 +104,11 @@ sf: Optional["Salesforce"] = None
 _LAST_CARD_SERIAL: Optional[str] = None
 _LAST_CARD_SEEN: float = 0.0
 
-# One-shot facilitator mode for the next created sign-in record
+# One-shot facilitator mode for the next created sign-in record.
+# Accessed from both the main thread and the gpiozero button-press thread;
+# always read or write under _FACILITATOR_LOCK.
 _NEXT_SIGNIN_IS_FACILITATOR: bool = False
+_FACILITATOR_LOCK = threading.Lock()
 
 # Network monitor instance
 _network_monitor: Optional["NetworkMonitor"] = None
@@ -141,46 +146,37 @@ def _show_idle_feedback() -> None:
     if not _HAS_HARDWARE_FEEDBACK:
         return
 
-    if _NEXT_SIGNIN_IS_FACILITATOR:
+    with _FACILITATOR_LOCK:
+        is_facilitator = _NEXT_SIGNIN_IS_FACILITATOR
+
+    if is_facilitator:
         provide_feedback(FeedbackState.FACILITATOR_SIGNIN)
     else:
         workshop = sf_get_current_workshop() if sf is not None else "No Event"
-        provide_feedback(
-            FeedbackState.READY_TO_SCAN,
-            workshop=workshop,
-            workshop_callback=sf_get_current_workshop,
-        )
-
-
-def arm_next_signin_as_facilitator() -> None:
-    """Arm facilitator mode for the next created sign-in."""
-    global _NEXT_SIGNIN_IS_FACILITATOR
-
-    _NEXT_SIGNIN_IS_FACILITATOR = True
-    LOG.info("Next sign-in armed as facilitator")
-    if _HAS_HARDWARE_FEEDBACK:
-        provide_feedback(FeedbackState.FACILITATOR_SIGNIN)
+        provide_feedback(FeedbackState.READY_TO_SCAN, workshop=workshop)
 
 
 def toggle_next_signin_as_facilitator() -> None:
     """Toggle facilitator mode for the next created sign-in.
 
-    If facilitator mode is currently armed, disarm it and return to the
-    normal ready feedback. Otherwise arm facilitator mode and show the
-    facilitator feedback screen.
+    Called from the gpiozero button-press thread, so the flag mutation is
+    protected by _FACILITATOR_LOCK.  Hardware feedback is triggered outside
+    the lock to keep the critical section short.
     """
     global _NEXT_SIGNIN_IS_FACILITATOR
 
-    if _NEXT_SIGNIN_IS_FACILITATOR:
-        _NEXT_SIGNIN_IS_FACILITATOR = False
-        LOG.info("Facilitator mode disarmed")
-        if _HAS_HARDWARE_FEEDBACK:
-            _show_idle_feedback()
-    else:
-        _NEXT_SIGNIN_IS_FACILITATOR = True
+    with _FACILITATOR_LOCK:
+        armed = not _NEXT_SIGNIN_IS_FACILITATOR
+        _NEXT_SIGNIN_IS_FACILITATOR = armed
+
+    if armed:
         LOG.info("Next sign-in armed as facilitator (toggled)")
         if _HAS_HARDWARE_FEEDBACK:
             provide_feedback(FeedbackState.FACILITATOR_SIGNIN)
+    else:
+        LOG.info("Facilitator mode disarmed")
+        if _HAS_HARDWARE_FEEDBACK:
+            _show_idle_feedback()
 
 
 def _escape_soql(value: str) -> str:
@@ -593,6 +589,12 @@ def process_signin_from_card_serial(
     """Main processing flow for a card serial: sign out open signins or create a new signin."""
     global _NEXT_SIGNIN_IS_FACILITATOR
 
+    # Atomically capture and clear facilitator mode so no error path can leave
+    # the flag armed for a future scan by a different person.
+    with _FACILITATOR_LOCK:
+        facilitator_mode = _NEXT_SIGNIN_IS_FACILITATOR
+        _NEXT_SIGNIN_IS_FACILITATOR = False
+
     if not card_serial:
         return 400, "invalid_serial"
 
@@ -612,7 +614,7 @@ def process_signin_from_card_serial(
         if ids:
             signout_status, signout_msg = sf_sign_out_signins_by_id(ids, now)
             if signout_status == 200:
-                if not _NEXT_SIGNIN_IS_FACILITATOR:
+                if not facilitator_mode:
                     return 200, "successfully_signed_out"
             else:
                 return signout_status, signout_msg
@@ -620,13 +622,10 @@ def process_signin_from_card_serial(
         # If error is not 404 (no records found), return the error
         return open_status, open_signins
 
-    # No open sign-ins found, create a new one
-    facilitator_mode = _NEXT_SIGNIN_IS_FACILITATOR
+    # No open sign-ins found (or signed out in facilitator mode), create a new one
     create_status, create_result = sf_create_signin_for_contact(
         contact_id, now, is_facilitator=facilitator_mode
     )
-    if create_status == 201 and facilitator_mode:
-        _NEXT_SIGNIN_IS_FACILITATOR = False
     return create_status, create_result
 
 
@@ -797,6 +796,7 @@ if __name__ == "__main__":
 
     if _HAS_HARDWARE_FEEDBACK:
         register_facilitator_button(toggle_next_signin_as_facilitator)
+        register_idle_callback(_show_idle_feedback)
 
     # Start network monitor
     if _HAS_NETWORK_MONITOR:

--- a/wiring.md
+++ b/wiring.md
@@ -30,9 +30,13 @@
 
 ## Facilitator Button
 - One side → GPIO24 (Pin 18) by default
-- Other side → Pi GND
+- Other side → Pi 3.3V (Pin 1 or Pin 17)
 
-The input uses the Pi's internal pull-up resistor, so the button should be wired as a simple momentary switch to ground. You can change the pin with `FACILITATOR_BUTTON_PIN` if needed.
+The input uses the Pi's internal pull-down resistor, so the button should be wired as a simple momentary switch to 3.3V. You can change the pin with `FACILITATOR_BUTTON_PIN` if needed.
+
+> **Note:** Do not wire to the 5V rail (Pins 2/4) — GPIO pins are 3.3V logic and connecting 5V directly can damage the Pi.
+
+> **Pin conflict:** The RFID reader's optional IRQ line is also listed as GPIO24 above. If you connect the IRQ wire, use a different pin for the button and set `FACILITATOR_BUTTON_PIN` accordingly.
 
 ## 128x128 OLED Display (I2C, SSD1306)
 - VCC → Pi 3.3V (Pin 1) or 5V (Pin 2, check your display specs)


### PR DESCRIPTION
signin.py:
- Add threading.Lock (_FACILITATOR_LOCK) protecting _NEXT_SIGNIN_IS_FACILITATOR against the gpiozero button-press thread racing the main scan loop
- Capture and clear facilitator flag atomically at the top of process_signin_from_card_serial so every error-return path clears it, preventing the flag leaking to a future scan by a different person
- Remove dead arm_next_signin_as_facilitator (never called; toggle covers both cases)
- Remove dead workshop_callback arg from provide_feedback call site
- Read facilitator flag under lock in _show_idle_feedback and toggle
- Register _show_idle_feedback as idle callback so error-timeout timer shows the correct screen (facilitator or normal) after clearing

feedback_hardware.py:
- Add _on_idle_callback / register_idle_callback: lets signin.py inject the idle-screen logic so _schedule_led_and_oled_clear no longer hardcodes READY_TO_SCAN (which was silently clobbering the facilitator display)
- Remove dead button init block from _initialize_hardware; button setup lives exclusively in register_facilitator_button
- Remove stale _facilitator_button from _initialize_hardware global decl
- Remove dead workshop_callback parameter from provide_feedback
- Switch Button pull_up=True -> pull_up=False (active-high wiring)
- OLED rendering: switch PIL image mode "1" -> "L" so Pillow anti-aliases TrueType glyphs; threshold to 1-bit via .convert("1") before display
- Bump TrueType font size 12 -> 14 for better legibility
- Add _measure_text and _wrap_and_clip helpers; _display_text now word-wraps long lines and clips to the lines that fit on screen

wiring.md:
- Update facilitator button wiring to pull-down (switch to 3.3V, not GND)
- Add 5V damage warning and GPIO24/IRQ pin-conflict note