### PR TITLE
Fix workshop calendar sync creating events 12 hours early

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,10 @@ WORKSHOP_END_FIELD=End_Time__c
 WORKSHOP_WEEKDAY_FIELD=Weekday__c
 WORKSHOP_DATE_FIELD=Workshop_Date__c
 WORKSHOP_LOOKAHEAD_MINUTES=90
+# IANA timezone for workshop time matching - independent of the host OS
+# clock's timezone (Raspberry Pi OS defaults to UTC unless reconfigured).
+# Leave blank to fall back to the OS's local timezone instead.
+WORKSHOP_TIMEZONE=Pacific/Auckland
 
 # Workshop calendar sync (one-off events from an ICS feed)
 # Leave WORKSHOP_ICS_URL blank to disable calendar sync entirely.

--- a/README.md
+++ b/README.md
@@ -250,6 +250,9 @@ calendar so both the RFID and terminal sign-in flows can tag sign-ins with them:
 - Sync is disabled entirely when `WORKSHOP_ICS_URL` is unset
 
 ## Notes
-- Uses OS local timezone (with DST) for workshop matching
+- Workshop matching (recurring and calendar-synced) uses `WORKSHOP_TIMEZONE` (with DST),
+  not the host OS clock's timezone - a Pi left on its default UTC clock would
+  otherwise cause workshop times to be off by the local UTC offset. Leave
+  `WORKSHOP_TIMEZONE` blank to fall back to the OS's local timezone instead.
 - RFIDs that match open sign-ins trigger sign-out; otherwise a new sign-in is created
 - Debounce prevents repeated scans when a card is held over the reader

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,8 @@ requests
 # Workshop calendar sync (ICS feed parsing)
 icalendar
 recurring-ical-events
+# Provides the IANA tz database for zoneinfo on platforms without system tzdata
+tzdata
 
 # mfrc522 is Raspberry-Pi specific; install only on Linux
 mfrc522; sys_platform == "linux"

--- a/signin.py
+++ b/signin.py
@@ -17,6 +17,7 @@ import os
 import threading
 import time
 from typing import Any, Dict, List, Optional, Tuple, Union
+from zoneinfo import ZoneInfo
 
 try:
     from dotenv import load_dotenv
@@ -87,6 +88,12 @@ WORKSHOP_END_FIELD = os.getenv("WORKSHOP_END_FIELD", "End_Time__c")
 WORKSHOP_WEEKDAY_FIELD = os.getenv("WORKSHOP_WEEKDAY_FIELD", "Weekday__c")
 WORKSHOP_DATE_FIELD = os.getenv("WORKSHOP_DATE_FIELD", "Workshop_Date__c")
 WORKSHOP_LOOKAHEAD_MINUTES = int(os.getenv("WORKSHOP_LOOKAHEAD_MINUTES", "30"))
+
+# IANA timezone used for all workshop time-of-day matching, independent of the
+# host OS clock's timezone (Raspberry Pi OS defaults to UTC unless explicitly
+# reconfigured, which previously caused workshop times to be off by the local
+# UTC offset). Leave blank to fall back to the OS's local timezone.
+WORKSHOP_TIMEZONE = os.getenv("WORKSHOP_TIMEZONE", "Pacific/Auckland")
 
 # Workshop calendar sync (one-off events pulled from an ICS feed; see
 # workshop_calendar_sync.py). Sync is disabled when WORKSHOP_ICS_URL is unset.
@@ -239,6 +246,31 @@ def toggle_next_signin_as_facilitator() -> None:
         LOG.info("Facilitator mode disarmed")
         if _HAS_HARDWARE_FEEDBACK:
             _show_idle_feedback()
+
+
+_workshop_tzinfo_cache: Dict[str, Optional[datetime.tzinfo]] = {}
+
+
+def _get_workshop_tzinfo() -> Optional[datetime.tzinfo]:
+    """Resolve WORKSHOP_TIMEZONE to a tzinfo, or None to fall back to OS local time.
+
+    Cached since ZoneInfo lookups touch the system/tzdata database.
+    """
+    if WORKSHOP_TIMEZONE in _workshop_tzinfo_cache:
+        return _workshop_tzinfo_cache[WORKSHOP_TIMEZONE]
+
+    tzinfo: Optional[datetime.tzinfo] = None
+    if WORKSHOP_TIMEZONE:
+        try:
+            tzinfo = ZoneInfo(WORKSHOP_TIMEZONE)
+        except Exception as exc:
+            LOG.warning(
+                "Invalid WORKSHOP_TIMEZONE %r (%s); falling back to OS local time",
+                WORKSHOP_TIMEZONE,
+                exc,
+            )
+    _workshop_tzinfo_cache[WORKSHOP_TIMEZONE] = tzinfo
+    return tzinfo
 
 
 def _escape_soql(value: str) -> str:
@@ -522,8 +554,11 @@ def sf_get_current_workshop(now: Optional[datetime.datetime] = None) -> str:
     Returns the name of the currently running or upcoming workshop,
     or "No Event" if none can be determined.
     """
-    # Use OS local timezone (handles DST) for matching against workshop times
-    now_local = (now or datetime.datetime.now(datetime.timezone.utc)).astimezone()
+    # Use WORKSHOP_TIMEZONE (handles DST) for matching against workshop times,
+    # not the host OS clock's timezone - see _get_workshop_tzinfo.
+    now_local = (now or datetime.datetime.now(datetime.timezone.utc)).astimezone(
+        _get_workshop_tzinfo()
+    )
     # Convert to 1=Sunday weekday format (Python's weekday() is 0=Monday)
     # Python: Mon=0, Tue=1, Wed=2, Thu=3, Fri=4, Sat=5, Sun=6
     # Salesforce: Sun=1, Mon=2, Tue=3, Wed=4, Thu=5, Fri=6, Sat=7
@@ -907,6 +942,7 @@ if __name__ == "__main__":
             date_field=WORKSHOP_DATE_FIELD,
             oneoff_weekday=WORKSHOP_ONEOFF_WEEKDAY,
             sync_hour=WORKSHOP_SYNC_HOUR,
+            tz=_get_workshop_tzinfo(),
         )
         _calendar_sync.start()
         LOG.info("Workshop calendar sync enabled")

--- a/workshop_calendar_sync.py
+++ b/workshop_calendar_sync.py
@@ -57,6 +57,7 @@ class WorkshopCalendarSync:
         sync_hour: int = 4,
         fetch_timeout: float = ICS_FETCH_TIMEOUT_SECONDS,
         retry_interval: float = RETRY_INTERVAL_SECONDS,
+        tz: Optional[datetime.tzinfo] = None,
     ):
         self.ics_url = ics_url
         self.get_sf = get_sf
@@ -70,6 +71,9 @@ class WorkshopCalendarSync:
         self.sync_hour = sync_hour
         self.fetch_timeout = fetch_timeout
         self.retry_interval = retry_interval
+        # Pinned timezone for all "today"/time-of-day matching, independent of
+        # the host OS clock's timezone. None falls back to OS local time.
+        self.tz = tz
 
         self._running = False
         self._thread: Optional[threading.Thread] = None
@@ -134,10 +138,14 @@ class WorkshopCalendarSync:
             return True
         return isinstance(stats, dict) and "error" in stats
 
+    def _now_local(self, now: Optional[datetime.datetime] = None) -> datetime.datetime:
+        base = now or datetime.datetime.now(datetime.timezone.utc)
+        return base.astimezone(self.tz)
+
     def _seconds_until_next_run(
         self, now: Optional[datetime.datetime] = None
     ) -> float:
-        now_local = (now or datetime.datetime.now(datetime.timezone.utc)).astimezone()
+        now_local = self._now_local(now)
         next_run = now_local.replace(
             hour=self.sync_hour, minute=0, second=0, microsecond=0
         )
@@ -151,7 +159,7 @@ class WorkshopCalendarSync:
             LOG.debug("No ICS URL configured; skipping calendar sync")
             return {"skipped": "no_ics_url"}
 
-        now_local = (now or datetime.datetime.now(datetime.timezone.utc)).astimezone()
+        now_local = self._now_local(now)
         today = now_local.date()
 
         try:
@@ -214,8 +222,8 @@ class WorkshopCalendarSync:
         response.raise_for_status()
         calendar = icalendar.Calendar.from_ical(response.content)
 
-        day_start = datetime.datetime.combine(date, datetime.time.min).astimezone()
-        day_end = datetime.datetime.combine(date, datetime.time.max).astimezone()
+        day_start = self._local_day_bound(date, datetime.time.min)
+        day_end = self._local_day_bound(date, datetime.time.max)
 
         occurrences = recurring_ical_events.of(calendar).between(day_start, day_end)
 
@@ -244,6 +252,12 @@ class WorkshopCalendarSync:
             # A bare `date` (no time component) means an all-day event.
             return {"name": name, "all_day": True, "start_time": None, "end_time": None}
 
+        LOG.debug(
+            "Parsing ICS event %r: raw DTSTART=%r (tzinfo=%r)",
+            name,
+            dtstart,
+            dtstart.tzinfo,
+        )
         start_local = self._to_local(dtstart)
 
         dtend_prop = component.get("DTEND")
@@ -256,11 +270,23 @@ class WorkshopCalendarSync:
             "end_time": end_local.time(),
         }
 
-    @staticmethod
-    def _to_local(value: datetime.datetime) -> datetime.datetime:
+    def _local_day_bound(self, date: datetime.date, time_of_day: datetime.time) -> datetime.datetime:
+        """A naive (date, time) combination, attached to self.tz (or OS local)."""
+        naive = datetime.datetime.combine(date, time_of_day)
+        if self.tz is not None:
+            return naive.replace(tzinfo=self.tz)
+        return naive.astimezone()
+
+    def _to_local(self, value: datetime.datetime) -> datetime.datetime:
         if value.tzinfo is None:
-            value = value.replace(tzinfo=datetime.timezone.utc)
-        return value.astimezone()
+            # A "floating" time (RFC 5545) has no defined zone. For a single-
+            # timezone calendar the sane reading is that it's already wall-clock
+            # time in the workshop timezone - not UTC, which would silently
+            # shift it by the UTC offset (e.g. 12h early for Pacific/Auckland).
+            if self.tz is not None:
+                return value.replace(tzinfo=self.tz)
+            return value.astimezone()  # naive -> OS-local, no shift
+        return value.astimezone(self.tz)
 
     def _get_existing_workshop_titles_for_today(
         self, sf: Any, now_local: datetime.datetime


### PR DESCRIPTION
Pin workshop time-of-day matching to an explicit WORKSHOP_TIMEZONE (default Pacific/Auckland) via zoneinfo instead of relying on the host OS clock's timezone, and treat floating (timezone-naive) ICS timestamps as already being in that zone rather than UTC - both previously caused a same-day 12-hour offset for certain event encodings. Applies to both sf_get_current_workshop() and WorkshopCalendarSync. Adds tzdata as an explicit dependency and a debug log of each parsed event's raw DTSTART/tzinfo to aid future diagnosis.